### PR TITLE
ESLINT-24 updated readme with updated lint scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ Replace npm scripts and set lint to false within the service key to disable runn
 {
   // ...
   "scripts": {
-    "lint": "eslint -f unix --ext .js,.ts src/**",
-    "lint:fix": "eslint -f unix --ext .js,.ts src/** --fix",
+    "lint": "eslint -f unix 'src/**/*.ts'",
+    "lint:fix": "eslint -f unix 'src/**/*.ts' --fix",
     "test": "export PORT=3002 && export AWS_REGION=us-east-1 && export AWS_ACCESS_KEY_ID=test && export AWS_SECRET_ACCESS_KEY=test && serve test && npm run lint"
   },
   // ...


### PR DESCRIPTION
--ext has no effect when using globs (https://github.com/eslint/eslint/issues/5452), so i removed them. I updated the glob to only look for .ts files. also added quotes to ensure that the glob pattern is read the same regardless of the shell (https://eslint.org/docs/user-guide/command-line-interface). 