### PR TITLE
Disable no-unsafe-enum-comparison rule for TypeScript 6.0 compatibility

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -199,6 +199,9 @@ const tsConfigurations = [
       // typeof any === "evil".
       '@typescript-eslint/no-explicit-any': 'error',
       '@typescript-eslint/prefer-regexp-exec': 'off', // RegExp.exec() is *only* slightly faster than String.match() so will leave this off and not worth updating our code
+
+      '@typescript-eslint/no-unsafe-enum-comparison': 'off', // with typescript v6, this rule behave differently and start reporting error when number is compared with enum e.g. `if (statusCode === StatusCodes.OK) { ... }` which is a common pattern in our codebase.
+
       // We're smarter than the default (15). Right?
       'sonarjs/cognitive-complexity': ['error', 24],
       'sonarjs/different-types-comparison': 'off', // duplicate of @typescript-eslint/no-unnecessary-condition

--- a/index.mjs
+++ b/index.mjs
@@ -201,7 +201,7 @@ const tsConfigurations = [
       '@typescript-eslint/prefer-regexp-exec': 'off', // RegExp.exec() is *only* slightly faster than String.match() so will leave this off and not worth updating our code
 
       '@typescript-eslint/no-unsafe-enum-comparison': 'off', // With TypeScript v6, this rule behaves differently and starts reporting errors when a number is compared with an enum, e.g. `if (statusCode === StatusCodes.OK) { ... }`, which is a common pattern in our codebase.
-      
+
       // We're smarter than the default (15). Right?
       'sonarjs/cognitive-complexity': ['error', 24],
       'sonarjs/different-types-comparison': 'off', // duplicate of @typescript-eslint/no-unnecessary-condition

--- a/index.mjs
+++ b/index.mjs
@@ -200,8 +200,8 @@ const tsConfigurations = [
       '@typescript-eslint/no-explicit-any': 'error',
       '@typescript-eslint/prefer-regexp-exec': 'off', // RegExp.exec() is *only* slightly faster than String.match() so will leave this off and not worth updating our code
 
-      '@typescript-eslint/no-unsafe-enum-comparison': 'off', // with typescript v6, this rule behave differently and start reporting error when number is compared with enum e.g. `if (statusCode === StatusCodes.OK) { ... }` which is a common pattern in our codebase.
-
+      '@typescript-eslint/no-unsafe-enum-comparison': 'off', // With TypeScript v6, this rule behaves differently and starts reporting errors when a number is compared with an enum, e.g. `if (statusCode === StatusCodes.OK) { ... }`, which is a common pattern in our codebase.
+      
       // We're smarter than the default (15). Right?
       'sonarjs/cognitive-complexity': ['error', 24],
       'sonarjs/different-types-comparison': 'off', // duplicate of @typescript-eslint/no-unnecessary-condition

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@checkdigit/eslint-config",
-  "version": "11.7.0",
+  "version": "11.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@checkdigit/eslint-config",
-      "version": "11.7.0",
+      "version": "11.8.0",
       "license": "MIT",
       "devDependencies": {
         "@checkdigit/prettier-config": "^7.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@checkdigit/eslint-config",
-  "version": "11.7.0",
+  "version": "11.8.0",
   "private": false,
   "description": "Check Digit standard eslint configuration",
   "keywords": [


### PR DESCRIPTION
Fixes #251 